### PR TITLE
Create swopfi-account-script.ride

### DIFF
--- a/swopfi-account-script.ride
+++ b/swopfi-account-script.ride
@@ -1,0 +1,60 @@
+{-# STDLIB_VERSION 5 #-}
+{-# CONTENT_TYPE DAPP #-}
+{-# SCRIPT_TYPE ACCOUNT #-}
+
+# ATTENTION: Set correct addresses
+let governanceAddr = Address(base58'3N5W8da2iiijVieA6qLGo7KzCJj8B19smWU')	# mainnet 3PLHVWCqA9DJPDbadUofTohnCULLauiDWhS
+let serviceAddr = Address(base58'3N9Tq8RmGw456c1eYphzoMyvtwJGrY98jfr') # address of service which is allowed to manage staking
+
+# START Part from 'https://github.com/swopfi/swopfi-smart-contracts/blob/master/dApps/SWOP/governance.ride'
+
+let keyLastInterest = "last_interest"
+let keyUserSWOPLocked = "_SWOP_amount"
+let keyUserLastInterest = "_last_interest"
+let scaleValue = 100000000 # 10^8
+
+func getLastInterestInfo () = {
+    let lastInterest = valueOrElse(getInteger(governanceAddr, keyLastInterest), 0)
+    lastInterest
+}
+
+func getUserSWOPLocked (user:Address) = valueOrElse(getInteger(governanceAddr, (toString(user) + keyUserSWOPLocked)), 0)
+
+func getUserInterestInfo (user:Address,lastInterest:Int) = {
+    let userSWOPAmount = getUserSWOPLocked(user)
+    let userLastInterest = getInteger(governanceAddr, (toString(user) + keyUserLastInterest))
+    let userLastInterestValue =     match userLastInterest {
+        case userLastInterest: Int => 
+            userLastInterest
+        case _ => 
+            lastInterest
+    }
+    (userLastInterestValue, userSWOPAmount)
+}
+
+func claimCalc(caller:Address) = {
+    let lastInterest = getLastInterestInfo()
+    let uifo = getUserInterestInfo(caller, lastInterest)
+    let userLastInterest = uifo._1
+    let userSWOPLocked = uifo._2
+    let claimAmount = fraction(userSWOPLocked, (lastInterest - userLastInterest), scaleValue)
+    let userNewInterest = lastInterest
+    (userNewInterest, claimAmount)
+}
+
+# END of part from swop.fi github
+
+@Callable(i)
+func restakeGovernance(minSWOPreward: Int) = {
+  if (i.caller != serviceAddr) then throw("Only staking service is allowed to call this func") else  
+  let claimAmount = claimCalc(this)._2
+
+  if (claimAmount < minSWOPreward) then throw("Amount to claim is less than minSWOPreward") else
+  strict z = invoke(governanceAddr, "claimAndStakeSWOP", [], [])
+  []
+}
+
+@Verifier(tx)
+func verify() = {
+  sigVerify(tx.bodyBytes, tx.proofs[0], tx.senderPublicKey)
+}


### PR DESCRIPTION
This account script which can be set to user's address and allows defi-helper to call claimAndStakeSWOP() on swop.fi governance contract on behalf of user